### PR TITLE
add `typeOnly` specifer to `Edge`

### DIFF
--- a/src/common/extraction/extractGraph.ts
+++ b/src/common/extraction/extractGraph.ts
@@ -123,10 +123,13 @@ export async function extractGraphUncached(configFileName?: string): Promise<Edg
 				const { resolvedFileName, isExternalLibraryImport } = resolvedModule
 				const normalizedTargetFileName = path.relative(rootDir, resolvedFileName)
 
+				const typeOnly = x.importClause?.isTypeOnly ?? false;
+
 				imports.push({
 					source: normalizeWindowsPaths(normalizedSourceFileName),
 					target: normalizeWindowsPaths(normalizedTargetFileName),
-					external: isExternalLibraryImport ?? false
+					external: isExternalLibraryImport ?? false,
+					typeOnly
 				})
 			}
 		})

--- a/src/common/extraction/graph.ts
+++ b/src/common/extraction/graph.ts
@@ -2,6 +2,7 @@ export type Edge = {
 	source: string
 	target: string
 	external: boolean
+	typeOnly: boolean
 }
 
 export type Graph = Edge[]

--- a/src/slices/projection/slicingProjections.spec.ts
+++ b/src/slices/projection/slicingProjections.spec.ts
@@ -5,7 +5,8 @@ describe("slicingProjections", () => {
 		const edge = {
 			source: "src/service/blub/Service.ts",
 			target: "src/facade/bla/Facade.ts",
-			external: false
+			external: false,
+			typeOnly: false
 		}
 		expect(sliceByPattern("src/(**)/")(edge)?.sourceLabel).toEqual("service")
 		expect(sliceByPattern("src/(**)/")(edge)?.targetLabel).toEqual("facade")
@@ -15,7 +16,8 @@ describe("slicingProjections", () => {
 		const edge = {
 			source: "src/service/Service.ts",
 			target: "src/facade/Facade.ts",
-			external: false
+			external: false,
+			typeOnly: false
 		}
 		expect(sliceByPattern("src/(**)")(edge)?.sourceLabel).toEqual("service")
 		expect(sliceByPattern("src/(**)")(edge)?.targetLabel).toEqual("facade")

--- a/test/files/integration/integration.spec.ts
+++ b/test/files/integration/integration.spec.ts
@@ -1,4 +1,5 @@
 import { FileConditionBuilder, filesOfProject } from "../../../src/files/fluentapi/files"
+import { extractGraph } from "../../../src/common/extraction/extractGraph"
 import path from "path"
 describe("Integration test", () => {
 	let files: FileConditionBuilder
@@ -56,6 +57,7 @@ describe("Integration test", () => {
 				dependency: {
 					cumulatedEdges: [
 						{
+							typeOnly: false,
 							external: false,
 							source: "src/components/ATest/ATest.ts",
 							target: "src/components/BTest/BTest.ts"
@@ -99,6 +101,7 @@ describe("Integration test", () => {
 						cumulatedEdges: [
 							{
 								external: false,
+								typeOnly: false,
 								source: "src/services/Service.ts",
 								target: "src/controllers/Controller.ts"
 							}
@@ -110,6 +113,7 @@ describe("Integration test", () => {
 						cumulatedEdges: [
 							{
 								external: false,
+								typeOnly: false,
 								source: "src/controllers/Controller.ts",
 								target: "src/services/Service.ts"
 							}
@@ -134,4 +138,18 @@ describe("Integration test", () => {
 
 		expect(violations).toEqual([])
 	})
+	
+
+	it("does mark type only imports", async () => {
+		const graph = await extractGraph(path.resolve(__dirname, "samples", "typeimports", "tsconfig.json"));
+
+		const typeOnly = graph.find(e => e.source.endsWith('typeOnly.ts'));
+		const valueImport = graph.find(e => e.source.endsWith('valueImport.ts'));
+
+		expect(typeOnly).toBeDefined();
+		expect(valueImport).toBeDefined();
+		expect(typeOnly).toEqual(expect.objectContaining({ typeOnly: true }));
+		expect(valueImport).toEqual(expect.objectContaining({ typeOnly: false }));
+	})
+
 })

--- a/test/files/integration/samples/typeimports/src/data.ts
+++ b/test/files/integration/samples/typeimports/src/data.ts
@@ -1,0 +1,6 @@
+export interface DataType {
+    value: string;
+};
+
+const data: DataType = {value: 'data'};
+export default data;

--- a/test/files/integration/samples/typeimports/src/typeOnly.ts
+++ b/test/files/integration/samples/typeimports/src/typeOnly.ts
@@ -1,0 +1,3 @@
+import type { DataType } from "./data";
+
+const _: DataType = {value: ''};

--- a/test/files/integration/samples/typeimports/src/valueImport.ts
+++ b/test/files/integration/samples/typeimports/src/valueImport.ts
@@ -1,0 +1,1 @@
+import _ from './data';

--- a/test/files/integration/samples/typeimports/tsconfig.json
+++ b/test/files/integration/samples/typeimports/tsconfig.json
@@ -1,0 +1,60 @@
+{
+	"compilerOptions": {
+		"baseUrl": ".",
+		/* Basic Options */
+		"target": "es5" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */,
+		"module": "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */,
+		"lib": ["es2019", "dom"] /* Specify library files to be included in the compilation. */,
+		// "allowJs": true,                       /* Allow javascript files to be compiled. */
+		// "checkJs": true,                       /* Report errors in .js files. */
+		// "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
+		// "declaration": true,                   /* Generates corresponding '.d.ts' file. */
+		// "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
+		// "sourceMap": true,                     /* Generates corresponding '.map' file. */
+		// "outFile": "./",                       /* Concatenate and emit output to single file. */
+		// "outDir": "./",                        /* Redirect output structure to the directory. */
+		"rootDir": "." /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */,
+		// "composite": true,                     /* Enable projectCycles compilation */
+		// "removeComments": true,                /* Do not emit comments to output. */
+		"noEmit": true /* Do not emit outputs. */,
+		// "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
+		// "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
+		// "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+
+		/* Strict Type-Checking Options */
+		"strict": true /* Enable all strict type-checking options. */,
+		"noImplicitAny": true /* Raise error on expressions and declarations with an implied 'any' type. */,
+		//"strictNullChecks": true,              /* Enable strict null checks. */
+		// "strictFunctionTypes": true,           /* Enable strict checking of function types. */
+		// "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
+		// "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
+		// "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
+		// "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
+		/* Additional Checks */
+		// "noUnusedLocals": true,                /* Report errors on unused locals. */
+		// "noUnusedParameters": true,            /* Report errors on unused parameters. */
+		// "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
+		// "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
+
+		/* Module Resolution Options */
+		// "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (NumberNode.js) or 'classic' (TypeScript pre-1.6). */
+		// "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
+		// "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+		// "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the projectCycles at runtime. */
+		// "typeRoots": [],                       /* List of folders to include type definitions from. */
+		// "types": [],                           /* Type declaration files to be included in compilation. */
+		// "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+		"esModuleInterop": true,
+		// "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
+
+		/* Source Map Options */
+		// "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
+		// "mapRoot": "",                         /* Specify the location where debugger should locate map files instead of generated locations. */
+		// "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
+		// "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+
+		/* Experimental Options */
+		// "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
+		// "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+	}
+}

--- a/test/slices/integration/integration.spec.ts
+++ b/test/slices/integration/integration.spec.ts
@@ -27,6 +27,7 @@ describe("Integration test", () => {
 					{
 						source: "src/services/util/Service.ts",
 						target: "src/controllers/Controller.ts",
+						typeOnly: false,
 						external: false
 					}
 				]
@@ -48,6 +49,7 @@ describe("Integration test", () => {
 					cumulatedEdges: [
 						{
 							external: false,
+							typeOnly: false,
 							source: "src/facades/another/AnotherFacade.ts",
 							target: "src/facades/one/OneFacade.ts"
 						}
@@ -83,6 +85,7 @@ describe("Integration test", () => {
 					{
 						source: "src/services/util/Service.ts",
 						target: "src/controllers/Controller.ts",
+						typeOnly: false,
 						external: false
 					}
 				]
@@ -110,6 +113,7 @@ describe("Integration test", () => {
 					{
 						source: "src/services/util/Service.ts",
 						target: "src/controllers/Controller.ts",
+							typeOnly: false,
 						external: false
 					}
 				]


### PR DESCRIPTION
Adds a `typeOnly` specifier (in the same way `external` is used).
This will add the ability to filter by this prop later on.

related to: https://github.com/ts-arch/ts-arch/issues/48