### PR TITLE
docs: fix import path in Nx example

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ The following example illustrates this:
 
 ```typescript
 import "tsarch/dist/jest"
-import {slicesOfProject} from "tsarch" 
+import {slicesOfNxProject} from "tsarch" 
 import * as path from "path"
 
 describe("architecture", ()=> {


### PR DESCRIPTION
Fix a wrong import path of `slicesOfNxProject` in the code example of "Dependency checks on nx monorepositories"